### PR TITLE
Add unicast discovery and fix Windows support

### DIFF
--- a/examples/basic/anddemo.py
+++ b/examples/basic/anddemo.py
@@ -40,6 +40,7 @@ class BasicClass(object):
     def stop(self):
         self.sd.stop()
 
+
 def main():
     basic = BasicClass()
 
@@ -61,6 +62,7 @@ def main():
 
     print('threads stopped')
     sys.exit(0)
+
 
 if __name__ == "__main__":
     main()

--- a/pymachinetalk/dns_sd.py
+++ b/pymachinetalk/dns_sd.py
@@ -88,7 +88,8 @@ class Service(object):
     def _update_uri(self):
         url = urlparse(self._raw_uri)
         host = url.hostname
-        if host.lower() in self.host_name.lower():  # hostname is in form .local. and host in .local
+        if not (host is None or self.host_name is None) and \
+           host.lower() in self.host_name.lower():  # hostname is in form .local. and host in .local
             netloc = url.netloc
             netloc = netloc.replace(host, self.host_address)
             new_url = url._replace(netloc=netloc)  # use resolved address

--- a/pymachinetalk/dns_sd.py
+++ b/pymachinetalk/dns_sd.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import socket
 from zeroconf import ServiceBrowser, Zeroconf, ServiceInfo
 import six
@@ -79,7 +80,7 @@ class Service(object):
         self._raw_uri = info.properties.get(b'dsn', b'').decode()
         self.uuid = info.properties.get(b'uuid', b'').decode()
         self.version = info.properties.get(b'version', b'')
-        self.host_name = info.server.decode()
+        self.host_name = info.server
         try:
             self.host_address = str(socket.inet_ntoa(info.address))
         except Exception:
@@ -88,13 +89,9 @@ class Service(object):
 
     def _update_uri(self):
         url = urlparse(self._raw_uri)
-        try:
-            host = url.hostname.decode()
-        except Exception:
-            self._uri = ''
-            return
+        host = url.hostname
         if host.lower() in self.host_name.lower():  # hostname is in form .local. and host in .local
-            netloc = url.netloc.decode()
+            netloc = url.netloc
             netloc = netloc.replace(host, self.host_address)
             new_url = url._replace(netloc=netloc)  # use resolved address
             self.uri = new_url.geturl()

--- a/pymachinetalk/halremote.py
+++ b/pymachinetalk/halremote.py
@@ -158,7 +158,7 @@ class RemoteComponent(ComponentBase, RemoteComponentBase, ServiceContainer):
 
         comp = rx.comp[0]
         for rpin in comp.pin:
-            name = rpin.name.split('.')[1]
+            name = '.'.join(rpin.name.split('.')[1:])
             lpin = self.pinsbyname[name]
             lpin.handle = rpin.handle
             self.pinsbyhandle[rpin.handle] = lpin

--- a/pymachinetalk/tests/test_dns_sd.py
+++ b/pymachinetalk/tests/test_dns_sd.py
@@ -1,5 +1,4 @@
 import pytest
-import socket
 
 
 @pytest.fixture

--- a/setup.py
+++ b/setup.py
@@ -30,10 +30,13 @@ else:
 from distutils.spawn import find_executable
 
 requirements = ['pyzmq',
-                'zeroconf',
                 'machinetalk-protobuf',
                 'fysom',
                 'six']
+if sys.version_info <= (3, 3):
+    requirements.append('zeroconf<=0.19.1')  # freeze version
+else:
+    requirements.append('zeroconf')
 
 if __name__ == '__main__':
     setup(name="pymachinetalk",

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ requirements = ['pyzmq',
 
 if __name__ == '__main__':
     setup(name="pymachinetalk",
-          version="0.9.103",
+          version="0.10.0",
           description="Python bindings for Machinetalk",
           author="Alexander Roessler",
           author_email="alex@machinekoder.com",


### PR DESCRIPTION
* Adds the option to use unicast DNS-SD for service discovery
* Fix to resolve of hostnames on Windows
* fix problem with HAL pins that contain dots

NOTE: unicast mode depends on an unmerged pymachinetalk PR: https://github.com/jstasiak/python-zeroconf/pull/124

Maybe the documentation in the README should be updated to include unicast mode.