### PR TITLE
Update for zeroconf API changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 sudo: false
 language: python
 python:
-  - 2.7
   - 3.6
   - 3.7
+  - 3.8
 #env:
 #  - TOX_ENV=py
 #  - TOX_ENV=flake8

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ sudo apt install python-pip
 sudo pip install pymachinetalk
 ```
 
+**Note:** If you need Python 2.7 support, use version 0.12.3 from PyPI.
+
 ## Install from Source
 
 ### Requirements

--- a/pymachinetalk/common.py
+++ b/pymachinetalk/common.py
@@ -27,13 +27,13 @@ def recurse_descriptor(descriptor, obj):
 
         if field.type == field.TYPE_BOOL:
             value = False
-        elif field.type == field.TYPE_DOUBLE or field.type == field.TYPE_FLOAT:
+        elif field.type in (field.TYPE_DOUBLE, field.TYPE_FLOAT):
             value = 0.0
-        elif (
-            field.type == field.TYPE_INT32
-            or field.type == field.TYPE_INT64
-            or field.type == field.TYPE_UINT32
-            or field.type == field.TYPE_UINT64
+        elif field.type in (
+            field.TYPE_INT32,
+            field.TYPE_INT64,
+            field.TYPE_UINT32,
+            field.TYPE_UINT64,
         ):
             value = 0
         elif field.type == field.TYPE_STRING:

--- a/pymachinetalk/dns_sd.py
+++ b/pymachinetalk/dns_sd.py
@@ -105,7 +105,8 @@ class Service(object):
         url = urlparse(self._raw_uri)
         host = url.hostname
         if (
-            not (host is None or self.host_name is None)
+            host is not None
+            and self.host_name is not None
             and host.lower() in self.host_name.lower()
         ):  # hostname is in form .local. and host in .local
             netloc = url.netloc
@@ -138,7 +139,7 @@ class ServiceDiscoveryFilter(object):
         if self.name not in info.name:
             match = False
         for name, value in six.iteritems(self.txt_records):
-            if not info.properties[name] == value:
+            if info.properties[name] != value:
                 match = False
                 break
         return match
@@ -155,7 +156,7 @@ class ServiceDiscovery(object):
         nameservers=None,
         lookup_interval=None,
     ):
-        """ Initialize the multicast or unicast DNS-SD service discovery instance.
+        """Initialize the multicast or unicast DNS-SD service discovery instance.
         @param service_type DNS-SD type use for discovery, does not need to be changed for Machinekit.
         @param filter_ Optional filter can be used to look for specific instances.
         @param nameservers Pass one or more nameserver addresses to enabled unicast service discovery.
@@ -295,9 +296,5 @@ class ServiceContainer(object):
                 cb(value)
 
     def _update_services_ready(self, _):
-        ready = True
-        for service in self._services:
-            if not service.ready:
-                ready = False
-                break
+        ready = all(service.ready for service in self._services)
         self.services_ready = ready

--- a/pymachinetalk/dns_sd.py
+++ b/pymachinetalk/dns_sd.py
@@ -2,9 +2,10 @@
 from __future__ import unicode_literals
 import re
 import socket
-from zeroconf import ServiceBrowser, Zeroconf, ServiceInfo
-import six
-from six.moves.urllib.parse import urlparse
+from urllib.parse import urlparse
+
+from zeroconf import ServiceBrowser, Zeroconf, ServiceInfo, ServiceListener
+
 
 # see: https://stackoverflow.com/a/15831118/5768039
 def ireplace(old, repl, text):
@@ -64,14 +65,15 @@ class Service(object):
         for cb in self.on_service_infos_updated:
             cb()
 
+    def update_service_info(self, info):
+        self._remove_service_info_entry(info.name)
+        self.service_infos.append(info)
+        self._update()
+        for cb in self.on_service_infos_updated:
+            cb()
+
     def remove_service_info(self, name):
-        updated = False
-        for info in list(self.service_infos):
-            if info.name == name:
-                self.service_infos.remove(info)
-                updated = True
-                break
-        if updated:
+        if self._remove_service_info_entry(name):
             self._update()
             for cb in self.on_service_infos_updated:
                 cb()
@@ -79,6 +81,15 @@ class Service(object):
     def clear_service_infos(self):
         self.service_infos = []
         self._update()
+
+    def _remove_service_info_entry(self, name):
+        updated = False
+        for info in list(self.service_infos):
+            if info.name == name:
+                self.service_infos.remove(info)
+                updated = True
+                break
+        return updated
 
     def _update(self):
         if any(self.service_infos):
@@ -96,9 +107,9 @@ class Service(object):
         self.version = info.properties.get(b'version', b'')
         self.host_name = info.server
         try:
-            self.host_address = six.ensure_str(socket.inet_ntoa(info.address))
+            self.host_address = str(socket.inet_ntoa(info.addresses[0]))
         except (OSError, socket.error):
-            self.host_address = six.ensure_str(info.address)
+            self.host_address = str(info.addresses[0])
         self._update_uri()
 
     def _update_uri(self):
@@ -138,7 +149,7 @@ class ServiceDiscoveryFilter(object):
         match = True
         if self.name not in info.name:
             match = False
-        for name, value in six.iteritems(self.txt_records):
+        for name, value in self.txt_records.items():
             if info.properties[name] != value:
                 match = False
                 break
@@ -148,7 +159,8 @@ class ServiceDiscoveryFilter(object):
         return self.name in name
 
 
-class ServiceDiscovery(object):
+class ServiceDiscovery(ServiceListener):
+
     def __init__(
         self,
         service_type='machinekit',
@@ -226,6 +238,16 @@ class ServiceDiscovery(object):
                 info
             ):
                 service.add_service_info(info)
+
+    def update_service(self, zeroconf, type_, name):
+        info = zeroconf.get_service_info(type_, name)
+        if info is None:
+            return
+        for service in self.services:
+            if self.filter.matches_service_info(info) and service.matches_service_info(
+                info
+            ):
+                service.update_service_info(info)
 
     @staticmethod
     def _verify_item_and_run(item, cmd):

--- a/pymachinetalk/halremote.py
+++ b/pymachinetalk/halremote.py
@@ -196,11 +196,8 @@ class RemoteComponent(ComponentBase, RemoteComponentBase, ServiceContainer):
             pin.value = 0.0
         elif pintype == HAL_BIT:
             pin.value = False
-        elif pintype == HAL_S32:
+        elif pintype in (HAL_S32, HAL_U32):
             pin.value = 0
-        elif pintype == HAL_U32:
-            pin.value = 0
-
         return pin
 
     def unsync_pins(self):

--- a/pymachinetalk/halremote.py
+++ b/pymachinetalk/halremote.py
@@ -1,8 +1,6 @@
 # coding=utf-8
 import threading
 
-import six
-
 from .dns_sd import ServiceContainer, Service
 from .common import ComponentBase
 
@@ -255,7 +253,7 @@ class RemoteComponent(ComponentBase, RemoteComponentBase, ServiceContainer):
         c = self._tx.comp.add()
         c.name = self.name
         c.no_create = self.no_create  # for now we create the component
-        for name, pin in six.iteritems(self.pinsbyname):
+        for name, pin in self.pinsbyname.items():
             p = c.pin.add()
             p.name = '%s.%s' % (self.name, name)
             p.type = pin.pintype

--- a/pymachinetalk/tests/test_dns_sd.py
+++ b/pymachinetalk/tests/test_dns_sd.py
@@ -15,8 +15,7 @@ def dns_sd():
 def sd():
     from pymachinetalk import dns_sd
 
-    sd = dns_sd.ServiceDiscovery()
-    return sd
+    return dns_sd.ServiceDiscovery()
 
 
 def test_registering_services_from_service_container_works(dns_sd, sd):

--- a/pymachinetalk/tests/test_dns_sd.py
+++ b/pymachinetalk/tests/test_dns_sd.py
@@ -144,7 +144,7 @@ class ServiceInfoFactory(object):
             type_=typestring,
             name='%s %s.%s' % (name, host, typestring),
             properties=properties,
-            address=socket.inet_aton(address or host),
+            addresses=[socket.inet_aton(address or host)],
             port=port,
             server=server,
         )
@@ -178,6 +178,24 @@ def test_service_discovered_updates_registered_services(dns_sd, sd, zeroconf):
     sd.register(service)
 
     sd.add_service(
+        zeroconf,
+        '_machinekit._tcp.local.',
+        'Foo on Bar 127.0.0.1._machinekit._tcp.local.',
+    )
+
+    assert service.ready is True
+
+
+def test_service_updated_updates_registered_services(dns_sd, sd, zeroconf):
+    service = dns_sd.Service(type_='halrcomp')
+    sd.register(service)
+
+    sd.add_service(
+        zeroconf,
+        '_machinekit._tcp.local.',
+        'Foo on Bar 127.0.0.1._machinekit._tcp.local.',
+    )
+    sd.update_service(
         zeroconf,
         '_machinekit._tcp.local.',
         'Foo on Bar 127.0.0.1._machinekit._tcp.local.',
@@ -260,6 +278,38 @@ def test_service_info_sets_all_relevant_values_of_service(dns_sd):
     assert service.uuid == '987654321'
     assert service.version == 5
     assert service.host_name == 'sandybox.local'
+    assert service.host_address == '10.0.0.10'
+
+
+def test_service_info_updates_all_values_of_service(dns_sd):
+    service = dns_sd.Service(type_='halrcomp')
+    service_info = ServiceInfoFactory().create(
+        name='Foo on Bar',
+        uuid=b'987654321',
+        version=5,
+        host='10.0.0.10',
+        protocol='tcp',
+        port=12456,
+        server='sandybox.local',
+    )
+    service.add_service_info(service_info)
+
+    service_info = ServiceInfoFactory().create(
+        name='Foo on Bar',
+        uuid=b'nBzl8w',
+        version=10,
+        host='10.0.0.10',
+        protocol='udp',
+        port=12456,
+        server='forest.local',
+    )
+    service.update_service_info(service_info)
+
+    assert service.uri == 'udp://10.0.0.10:12456'
+    assert service.name == service_info.name
+    assert service.uuid == 'nBzl8w'
+    assert service.version == 10
+    assert service.host_name == 'forest.local'
     assert service.host_address == '10.0.0.10'
 
 

--- a/pymachinetalk/tests/test_halremote_integration.py
+++ b/pymachinetalk/tests/test_halremote_integration.py
@@ -1,6 +1,7 @@
 # coding=utf-8
-import pytest
 import sys
+
+import pytest
 
 
 @pytest.fixture

--- a/setup.py
+++ b/setup.py
@@ -21,24 +21,15 @@ except ImportError:
         raise
 
 from distutils.command.clean import clean
+from distutils.command.build_py import build_py_2to3 as build_py
 
-if sys.version_info[0] == 3:
-    # Python 3
-    from distutils.command.build_py import build_py_2to3 as build_py
-else:
-    # Python 2
-    from distutils.command.build_py import build_py as build_py
+requirements = ['pyzmq', 'protobuf', 'machinetalk-protobuf', 'fysom', 'zeroconf']
 
-requirements = ['pyzmq', 'protobuf', 'machinetalk-protobuf', 'fysom', 'six>=1.12.0']
-if sys.version_info <= (3, 3):
-    requirements.append('zeroconf<=0.19.1')  # freeze version
-else:
-    requirements.append('zeroconf')
 
 if __name__ == '__main__':
     setup(
         name="pymachinetalk",
-        version="0.12.3",
+        version="0.13.0",
         description="Python bindings for Machinetalk",
         author="Alexander Roessler",
         author_email="alex@machinekoder.com",


### PR DESCRIPTION
The latest zeroconf API has changed. On the way of porting over pymachinetalk, I also threw out the Python 2 supporting, as it will not work anymore with the old zeroconf version.